### PR TITLE
Improve WorkThumb image fallbacks

### DIFF
--- a/components/WorkThumb.js
+++ b/components/WorkThumb.js
@@ -25,13 +25,28 @@ const Frame = styled.div`
 `
 
 const WorkThumb = ({ images, thumb }) => {
-  const imageSrc = images[3]?.link
-  const desktopSizeGif = thumb?.sizes[2].link
+  const imageSizes = Array.isArray(images) ? images : []
+  const lastImageSize = imageSizes[imageSizes.length - 1]?.link
+  const fallbackImageSize = imageSizes[0]?.link
+
+  const imageSrc = lastImageSize ?? fallbackImageSize ?? thumb?.link ?? null
+  const altText = thumb?.alt ?? "Work thumbnail"
+
+  const thumbSizes = Array.isArray(thumb?.sizes) ? thumb.sizes : []
+  const rawDesktopGif =
+    thumbSizes[thumbSizes.length - 1]?.link ?? thumb?.link ?? null
+  const desktopSizeGif = rawDesktopGif && rawDesktopGif !== imageSrc ? rawDesktopGif : null
 
   return (
     <Frame>
-      <Gif src={desktopSizeGif} alt={imageSrc} className="gif" />
-      <Image src={imageSrc} className="image" />
+      {desktopSizeGif ? (
+        <>
+          <Gif src={desktopSizeGif} alt={altText} className="gif" />
+          <Image src={imageSrc} alt={altText} className="image" />
+        </>
+      ) : (
+        <Image src={imageSrc} alt={altText} />
+      )}
     </Frame>
   )
 }

--- a/components/WorkThumb.js
+++ b/components/WorkThumb.js
@@ -33,9 +33,21 @@ const WorkThumb = ({ images, thumb }) => {
   const altText = thumb?.alt ?? "Work thumbnail"
 
   const thumbSizes = Array.isArray(thumb?.sizes) ? thumb.sizes : []
-  const rawDesktopGif =
-    thumbSizes[thumbSizes.length - 1]?.link ?? thumb?.link ?? null
-  const desktopSizeGif = rawDesktopGif && rawDesktopGif !== imageSrc ? rawDesktopGif : null
+  const validAnimatedLink = [...thumbSizes]
+    .reverse()
+    .map((size) => size?.link)
+    .find((link) =>
+      typeof link === "string" && /\.(gif|webp)(\?|$)/i.test(link),
+    )
+
+  const fallbackAnimatedLink =
+    typeof thumb?.link === "string" && /\.(gif|webp)(\?|$)/i.test(thumb.link)
+      ? thumb.link
+      : null
+
+  const rawDesktopGif = validAnimatedLink ?? fallbackAnimatedLink
+  const desktopSizeGif =
+    rawDesktopGif && rawDesktopGif !== imageSrc ? rawDesktopGif : null
 
   return (
     <Frame>

--- a/components/WorkThumb.js
+++ b/components/WorkThumb.js
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react"
 import styled from "styled-components"
 
 const Image = styled.img`
@@ -49,11 +50,46 @@ const WorkThumb = ({ images, thumb }) => {
   const desktopSizeGif =
     rawDesktopGif && rawDesktopGif !== imageSrc ? rawDesktopGif : null
 
+  const [animatedSrc, setAnimatedSrc] = useState(null)
+
+  useEffect(() => {
+    let isMounted = true
+    setAnimatedSrc(null)
+
+    if (!desktopSizeGif) {
+      return () => {
+        isMounted = false
+      }
+    }
+
+    const controller = new AbortController()
+
+    fetch(desktopSizeGif, { method: "HEAD", signal: controller.signal })
+      .then((response) => {
+        if (response.ok && isMounted) {
+          setAnimatedSrc(desktopSizeGif)
+        }
+      })
+      .catch(() => {
+        // keep poster image when animated asset fails to load
+      })
+
+    return () => {
+      isMounted = false
+      controller.abort()
+    }
+  }, [desktopSizeGif])
+
   return (
     <Frame>
-      {desktopSizeGif ? (
+      {animatedSrc ? (
         <>
-          <Gif src={desktopSizeGif} alt={altText} className="gif" />
+          <Gif
+            src={animatedSrc}
+            alt={altText}
+            className="gif"
+            onError={() => setAnimatedSrc(null)}
+          />
           <Image src={imageSrc} alt={altText} className="image" />
         </>
       ) : (

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,14 @@
 const withImages = require("next-images")
 
 module.exports = withImages({
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "i.vimeocdn.com",
+      },
+    ],
+  },
   webpack: (config, { isServer }) => {
     // Fixes npm packages that depend on `fs` module
     if (!isServer)

--- a/vimeo.js
+++ b/vimeo.js
@@ -2,14 +2,9 @@ import { Vimeo } from "vimeo"
 import { config } from "dotenv"
 // --- TEMP OVERRIDES (kill broken thumb) ---
 // If a video ID is listed here, we bypass Vimeo's animated lookup
-// and hand back this object instead (same shape your code expects).
+// and hand back the provided value instead (same shape your code expects).
 const TEMP_GIF_OVERRIDES = {
-  "/videos/1123017366": {
-    // Use a working animated GIF/WebP URL if you have one.
-    // For now, we point to the 1920x1080 POSTER so it never breaks.
-    link: "https://i.vimeocdn.com/video/2064552800-45cdc1ccefb61cd9b3a5519df92c64b309bd86e6fd34b374f195657b666661cc-d_1920x1080?&r=pad&region=us",
-    created_on: Math.floor(Date.now() / 1000)
-  }
+  "/videos/1123017366": null,
 };
 
 // add .env file to process in dev
@@ -135,7 +130,7 @@ export const getWorks = async (album_id = "8478566") => {
 // The site will use the most recently created thumbnail.
 // https://vimeo.com/blog/post/how-to-turn-your-videos-into-gifs/
 export const getMostRecentAnimatedThumb = async (uri) => {
-  if (TEMP_GIF_OVERRIDES[uri]) {
+  if (Object.prototype.hasOwnProperty.call(TEMP_GIF_OVERRIDES, uri)) {
     return TEMP_GIF_OVERRIDES[uri];
   }
   // (rest of the function stays the same)


### PR DESCRIPTION
## Summary
- derive the still thumbnail from the available Vimeo picture sizes instead of a hard-coded index
- ignore the animated overlay when its source matches the still to keep static thumbnails visible
- provide a consistent alt text for both static and animated layers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5ed0541d8833087afdb907da26ad7